### PR TITLE
Added a table listing the probabilities of lore check outcomes to the main markdown file

### DIFF
--- a/Guide to the Ultima Underworlds.md
+++ b/Guide to the Ultima Underworlds.md
@@ -2382,6 +2382,41 @@ The ``heading`` bits 0-1 are set with values as follows:
 
 Bit 2 is used to track if an identification attempt has been made. Value is set to 1 when the ``lore`` check is attempted. This prevents spamming ``lore`` checks when to brute-force identification. When the ``lore`` skill is increased this value is reset to 0 for all objects in the player inventory to allow re-examination.
 
+The following table lists the probabilities of each outcome depending on the player skill level
+
+| Player lore skill | Fully identified | Identified as being magical | Unidentified |
+|-------------------|------------------|-----------------------------|--------------|
+| 1                 | 0.0              | 22.58                       | 77.41        |
+| 2                 | 0.0              | 25.80                       | 74.19        |
+| 3                 | 0.0              | 29.03                       | 70.96        |
+| 4                 | 0.0              | 32.25                       | 67.74        |
+| 5                 | 0.0              | 35.48                       | 64.51        |
+| 6                 | 0.0              | 38.70                       | 61.29        |
+| 7                 | 0.0              | 41.93                       | 58.06        |
+| 8                 | 3.22             | 41.93                       | 54.83        |
+| 9                 | 6.45             | 41.93                       | 51.61        |
+| 10                | 9.67             | 41.93                       | 48.38        |
+| 11                | 12.90            | 41.93                       | 45.16        |
+| 12                | 16.12            | 41.93                       | 41.93        |
+| 13                | 19.35            | 41.93                       | 38.70        |
+| 14                | 22.58            | 41.93                       | 35.48        |
+| 15                | 25.80            | 41.93                       | 32.25        |
+| 16                | 29.03            | 41.93                       | 29.03        |
+| 17                | 32.25            | 41.93                       | 25.80        |
+| 18                | 35.48            | 41.93                       | 22.58        |
+| 19                | 38.70            | 41.93                       | 19.35        |
+| 20                | 41.93            | 41.93                       | 16.12        |
+| 21                | 45.16            | 41.93                       | 12.90        |
+| 22                | 48.38            | 41.93                       | 9.67         |
+| 23                | 51.61            | 41.93                       | 6.45         |
+| 24                | 54.83            | 41.93                       | 3.22         |
+| 25                | 58.06            | 41.93                       | 0.0          |
+| 26                | 61.29            | 38.70                       | 0.0          |
+| 27                | 64.51            | 35.48                       | 0.0          |
+| 28                | 67.74            | 32.25                       | 0.0          |
+| 29                | 70.96            | 29.03                       | 0.0          |
+| 30                | 74.19            | 25.80                       | 0.0          |
+
 ##### Casting
 Used to perform a skill check whenever the player casts a runic spell. ``Casting``.
 


### PR DESCRIPTION
I've been digging through the disassembly and taking notes. I got interested in the lore check, so I made a function that calculates the probabilities of each outcome of a skill check using a variable difficulty. Here's the code, using Python and numpy.

```python
import numpy as np
import pandas as pd
import matplotlib.pyplot as plt


def create_matrix_skillcheck_probabilities(difficulty: int) -> np.ndarray:
    """
    Returns a skill_values (30) x outcomes (4) array with the probabilities of skill checks.
    Layer 0 contains critical success, layer 1 success, layer 2 failure, and layer 3 critical failure.
    :param difficulty: Value that's subtracted from the player skill for the skill check
    :return: np.ndarray
    """
    roll_values = np.arange(0, 31) # 0 - 0x1F
    skill_values = np.arange(1, 31) # 1 - 30 in-game
    # Create grid of values
    matrix_roll_values, matrix_skill_values = np.meshgrid(roll_values, skill_values)
    matrix = matrix_skill_values - difficulty + matrix_roll_values
    critical_successes = (matrix > 29).sum(axis=1) / len(roll_values) * 100
    successes = ((matrix > 16) & (matrix <= 29)).sum(axis=1) / len(roll_values) * 100
    failures = ((matrix > 3) & (matrix <= 16)).sum(axis=1) / len(roll_values) * 100
    critical_failures = (matrix <= 3).sum(axis=1) / len(roll_values) * 100

    stack = np.vstack((critical_successes, successes, failures, critical_failures)).T
    assert np.allclose(stack.sum(axis=1), 100) # Probabilities should add up to 100

    return stack

```

Setting the difficulty to 8, and some additional processing, I converted the data converted into a table and a figure. I hope you find this a worthy addition to the document you're creating.

Note: This assumes the rolls have an equal probability, which I haven't tested but I think is safe to assume.